### PR TITLE
 Correct timestamp format #31 

### DIFF
--- a/flask_saml2/idp/sphandler.py
+++ b/flask_saml2/idp/sphandler.py
@@ -290,7 +290,7 @@ class SPHandler(object):
         formatting, and don't support the format produced by
         :meth:`datetime.datetime.isoformat`.
         """
-        return value.isoformat()
+        return value.replace(tzinfo=None).isoformat(timespec='seconds')
 
     def __str__(self):
         if self.display_name:

--- a/flask_saml2/sp/idphandler.py
+++ b/flask_saml2/sp/idphandler.py
@@ -266,7 +266,7 @@ class IdPHandler:
         formatting, and don't support the format produced by
         :meth:`datetime.datetime.isoformat`.
         """
-        return value.isoformat()
+        return value.replace(tzinfo=None).isoformat(timespec='seconds')
 
     def __str__(self):
         if self.display_name:

--- a/flask_saml2/sp/idphandler.py
+++ b/flask_saml2/sp/idphandler.py
@@ -266,7 +266,7 @@ class IdPHandler:
         formatting, and don't support the format produced by
         :meth:`datetime.datetime.isoformat`.
         """
-        return value.replace(tzinfo=None).isoformat(timespec='seconds')
+        return value.replace(tzinfo=None).isoformat(timespec='seconds') + 'Z'
 
     def __str__(self):
         if self.display_name:


### PR DESCRIPTION
This makes two changes to the timestamp format used in assertions.

    It removes the millisecond component, per issue 

    https://github.com/mx-moth/flask-saml2/issues/23, and
    It removes the timezone component, which is explicitly disallowed by the [SAML spec](https://www.oasis-open.org/committees/download.php/35711/sstc-saml-core-errata-2.0-wd-06-diff.pdf) (section 1.3.3)

I originally started working on this pull request because I believed my IDP (SimpleSAMLphp) did not tolerate timezones in timestamps, but it turns out that SimpleSAMLphp is actually slightly spec non-compliant itself and requires timestamps to be formatted as having a literal Z at the end.

For now I'm going to use a fork of flask-saml2 to prop up my IDP, and PR the upstream, although this lends credence to @ianlintner-wf's suggestion of making datetimes customizable

Please let me know if you suggest any other changes.