### PR TITLE
Make the relay_state optional in the response.

### DIFF
--- a/flask_saml2/sp/sp.py
+++ b/flask_saml2/sp/sp.py
@@ -37,7 +37,7 @@ class ServiceProvider:
     def login_successful(
         self,
         auth_data: AuthData,
-        relay_state: str,
+        redirect_to: str,
     ) -> Response:
         """ Called when a user is successfully logged on.
         Subclasses should override this if they want to do more
@@ -49,7 +49,9 @@ class ServiceProvider:
         but they *must* call ``super()``.
         """
         self.set_auth_data_in_session(auth_data)
-        return redirect(relay_state)
+        if not redirect_to:
+            redirect_to = self.get_login_return_url()
+        return redirect(redirect_to)
 
     # Service provider configuration
 
@@ -168,7 +170,7 @@ class ServiceProvider:
         for url in urls:
             if url is None:
                 continue
-            url = self.make_absolute_url(url)
+
             if self.is_valid_redirect_url(url):
                 return url
 

--- a/flask_saml2/sp/views.py
+++ b/flask_saml2/sp/views.py
@@ -79,7 +79,7 @@ class SingleLogout(SAML2View):
 class AssertionConsumer(SAML2View):
     def post(self):
         saml_request = request.form['SAMLResponse']
-        relay_state = request.form['RelayState']
+        relay_state = request.form.get('RelayState')
 
         for handler in self.sp.get_idp_handlers():
             try:


### PR DESCRIPTION
If relay_state isn't part of the outgoing request, it won't come back as a response.
In that case, the code wouldn't work.