### PR TITLE
 August-W: Made ServiceProvider more configurable without needing to extend it #20 

### DIFF
--- a/examples/sp.py
+++ b/examples/sp.py
@@ -5,16 +5,9 @@ from flask_saml2.sp import ServiceProvider
 from tests.idp.base import CERTIFICATE as IDP_CERTIFICATE
 from tests.sp.base import CERTIFICATE, PRIVATE_KEY
 
-
-class ExampleServiceProvider(ServiceProvider):
-    def get_logout_return_url(self):
-        return url_for('index', _external=True)
-
-    def get_default_login_return_url(self):
-        return url_for('index', _external=True)
-
-
-sp = ExampleServiceProvider()
+sp = ServiceProvider()
+sp.set_default_login_return_endpoint('index')
+sp.set_logout_return_endpoint('index')
 
 app = Flask(__name__)
 app.debug = True

--- a/examples/sp.py
+++ b/examples/sp.py
@@ -6,8 +6,8 @@ from tests.idp.base import CERTIFICATE as IDP_CERTIFICATE
 from tests.sp.base import CERTIFICATE, PRIVATE_KEY
 
 sp = ServiceProvider()
-sp.set_default_login_return_endpoint('index')
-sp.set_logout_return_endpoint('index')
+sp.default_login_return_endpoint = 'index'
+sp.logout_return_endpoint = 'index'
 
 app = Flask(__name__)
 app.debug = True

--- a/flask_saml2/sp/sp.py
+++ b/flask_saml2/sp/sp.py
@@ -166,7 +166,9 @@ class ServiceProvider:
     def get_default_login_return_url(self) -> Optional[str]:
         """The default URL to redirect users to once the have logged in.
         """
-        return url_for(self.default_login_return_endpoint, _external=True)
+        if self.default_login_return_endpoint!=None:
+            return url_for(self.default_login_return_endpoint, _external=True)
+        return None
 
     def get_login_return_url(self) -> Optional[str]:
         """Get the URL to redirect the user to now that they have logged in.
@@ -192,7 +194,9 @@ class ServiceProvider:
     def get_logout_return_url(self) -> Optional[str]:
         """The URL to redirect users to once they have logged out.
         """
-        return url_for(self.logout_return_endpoint, _external=True)
+        if self.logout_return_endpoint!=None:
+            return url_for(self.logout_return_endpoint, _external=True)
+        return None
 
     def is_valid_redirect_url(self, url: str) -> str:
         """Is this URL valid and safe to redirect to?

--- a/flask_saml2/sp/sp.py
+++ b/flask_saml2/sp/sp.py
@@ -34,10 +34,19 @@ class ServiceProvider:
     #: The name of the blueprint to generate.
     blueprint_name = 'flask_saml2_sp'
 
+    #: Set this to http or https
     scheme = 'http'
+
+    #: Set these to your desired endpoints
     logout_return_endpoint = None
     default_login_return_endpoint = None
     acs_redirect_endpoint = None
+
+    """
+    Set this value to override the default metadata return value
+    of :meth: `get_sp_entity_id`. By setting this, you can return
+    only the entity_id value, rather than the url to the full metadata xml.
+    """
     entity_id = None
 
     def login_successful(
@@ -82,9 +91,6 @@ class ServiceProvider:
         - :func:`~.utils.private_key_from_file`
         """
         return current_app.config['SAML2_SP']
-
-    def set_sp_entity_id(self, entity_id: str):
-        self.entity_id = entity_id
 
     def get_sp_entity_id(self) -> str:
         """The unique identifier for this Service Provider.
@@ -165,11 +171,6 @@ class ServiceProvider:
         """
         return url_for(self.blueprint_name + '.metadata', _external=True)
 
-    def set_default_login_return_endpoint(self, endpoint: str):
-        """Set the default URL to redirect users to once the have logged in.
-        """
-        self.default_login_return_endpoint = endpoint
-
     def get_default_login_return_url(self) -> Optional[str]:
         """The default URL to redirect users to once the have logged in.
         """
@@ -192,11 +193,6 @@ class ServiceProvider:
                 return url
 
         return None
-
-    def set_logout_return_endpoint(self, endpoint: str):
-        """Set the URL to redirect the user to now that they have logged out.
-        """
-        self.logout_return_endpoint = endpoint
 
     def get_logout_return_url(self) -> Optional[str]:
         """The URL to redirect users to once they have logged out.
@@ -332,14 +328,8 @@ class ServiceProvider:
             'contacts': [],
         }
 
-    def set_scheme(self, scheme):
-        self.scheme = scheme
-
     def get_scheme(self) -> str:
         return self.scheme
-
-    def set_acs_redirect_endpoint(self, acs_redirect_endpoint):
-        self.acs_redirect_endpoint = acs_redirect_endpoint
 
     def get_acs_redirect_endpoint(self) -> str:
         return self.acs_redirect_endpoint
@@ -352,7 +342,7 @@ class ServiceProvider:
 
         """Create a Flask :class:`flask.Blueprint` for this Service Provider.
         """
-        self.set_scheme(scheme)
+        self.scheme = scheme
 
         idp_bp = Blueprint(self.blueprint_name, 'flask_saml2.sp', template_folder='templates')
 

--- a/flask_saml2/sp/sp.py
+++ b/flask_saml2/sp/sp.py
@@ -339,9 +339,9 @@ class ServiceProvider:
 
     # With acs_redirect_url, you can set the url that the Access Consumer Service redirects to upon successful login
     # This is unnecessary if you expect a "relay_state" parameter in the SAML request to the ACS
-    def create_blueprint(self, login_endpoint='/login/', login_idp_endpoint='/login/idp/', 
-                            logout_endpoint='/logout/', acs_endpoint='/acs/', sls_endpoint='/sls/', 
-                            metadata_endpoint='/metadata.xml', scheme='http') -> Blueprint:
+    def create_blueprint(self, login_endpoint='/login/', login_idp_endpoint='/login/idp/',
+                         logout_endpoint='/logout/', acs_endpoint='/acs/', sls_endpoint='/sls/',
+                         metadata_endpoint='/metadata.xml', scheme='http') -> Blueprint:
 
         """Create a Flask :class:`flask.Blueprint` for this Service Provider.
         """

--- a/flask_saml2/sp/sp.py
+++ b/flask_saml2/sp/sp.py
@@ -38,6 +38,7 @@ class ServiceProvider:
     logout_return_endpoint = None
     default_login_return_endpoint = None
     acs_redirect_endpoint = None
+    entity_id = None
 
     def login_successful(
         self,
@@ -82,13 +83,19 @@ class ServiceProvider:
         """
         return current_app.config['SAML2_SP']
 
+    def set_sp_entity_id(self, entity_id: str):
+        self.entity_id = entity_id
+
     def get_sp_entity_id(self) -> str:
         """The unique identifier for this Service Provider.
         By default, this uses the metadata URL for this SP.
 
         See :func:`get_metadata_url`.
         """
-        return self.get_metadata_url()
+        if self.entity_id is None:
+            return self.get_metadata_url()
+        else:
+            return self.entity_id
 
     def get_sp_certificate(self) -> Optional[X509]:
         """Get the public certificate for this SP."""
@@ -158,7 +165,7 @@ class ServiceProvider:
         """
         return url_for(self.blueprint_name + '.metadata', _external=True)
 
-    def set_default_login_return_endpoint(self, endpoint) -> Optional[str]:
+    def set_default_login_return_endpoint(self, endpoint: str):
         """Set the default URL to redirect users to once the have logged in.
         """
         self.default_login_return_endpoint = endpoint
@@ -186,7 +193,7 @@ class ServiceProvider:
 
         return None
 
-    def set_logout_return_endpoint(self, endpoint):
+    def set_logout_return_endpoint(self, endpoint: str):
         """Set the URL to redirect the user to now that they have logged out.
         """
         self.logout_return_endpoint = endpoint

--- a/flask_saml2/sp/sp.py
+++ b/flask_saml2/sp/sp.py
@@ -166,7 +166,7 @@ class ServiceProvider:
     def get_default_login_return_url(self) -> Optional[str]:
         """The default URL to redirect users to once the have logged in.
         """
-        if self.default_login_return_endpoint!=None:
+        if self.default_login_return_endpoint is not None:
             return url_for(self.default_login_return_endpoint, _external=True)
         return None
 
@@ -194,7 +194,7 @@ class ServiceProvider:
     def get_logout_return_url(self) -> Optional[str]:
         """The URL to redirect users to once they have logged out.
         """
-        if self.logout_return_endpoint!=None:
+        if self.logout_return_endpoint is not None:
             return url_for(self.logout_return_endpoint, _external=True)
         return None
 
@@ -327,21 +327,21 @@ class ServiceProvider:
 
     def set_scheme(self, scheme):
         self.scheme = scheme
-    
+
     def get_scheme(self) -> str:
         return self.scheme
 
     def set_acs_redirect_endpoint(self, acs_redirect_endpoint):
         self.acs_redirect_endpoint = acs_redirect_endpoint
-    
+
     def get_acs_redirect_endpoint(self) -> str:
         return self.acs_redirect_endpoint
 
-    #With acs_redirect_url, you can set the url that the Access Consumer Service redirects to upon successful login 
-    #This is unnecessary if you expect a "relay_state" parameter in the SAML request to the ACS
-    def create_blueprint(self, login_endpoint='/login/', login_idp_endpoint='/login/idp/', \
-                        logout_endpoint='/logout/', acs_endpoint='/acs/', sls_endpoint='/sls/', \
-                        metadata_endpoint='/metadata.xml', scheme='http') -> Blueprint:
+    # With acs_redirect_url, you can set the url that the Access Consumer Service redirects to upon successful login
+    # This is unnecessary if you expect a "relay_state" parameter in the SAML request to the ACS
+    def create_blueprint(self, login_endpoint='/login/', login_idp_endpoint='/login/idp/', 
+                            logout_endpoint='/logout/', acs_endpoint='/acs/', sls_endpoint='/sls/', 
+                            metadata_endpoint='/metadata.xml', scheme='http') -> Blueprint:
 
         """Create a Flask :class:`flask.Blueprint` for this Service Provider.
         """

--- a/flask_saml2/sp/views.py
+++ b/flask_saml2/sp/views.py
@@ -80,7 +80,7 @@ class SingleLogout(SAML2View):
 class AssertionConsumer(SAML2View):
     def post(self):
         saml_request = request.form['SAMLResponse']
-        if self.sp.get_acs_redirect_endpoint() == None:
+        if self.sp.get_acs_redirect_endpoint() is None:
             relay_state = request.form['RelayState']
         else:
             relay_state = self.sp.make_absolute_url(self.sp.get_acs_redirect_endpoint())

--- a/flask_saml2/sp/views.py
+++ b/flask_saml2/sp/views.py
@@ -28,7 +28,8 @@ class Login(SAML2View):
         handler = self.sp.get_default_idp_handler()
         login_next = self.sp.get_login_return_url()
         if handler:
-            return redirect(url_for('.login_idp', entity_id=handler.entity_id, next=login_next))
+            return redirect(url_for('.login_idp', entity_id=handler.entity_id, next=login_next,
+                            _scheme=self.sp.get_scheme(), _external=True))
         return self.sp.render_template(
             'flask_saml2_sp/choose_idp.html',
             login_next=login_next,
@@ -79,7 +80,10 @@ class SingleLogout(SAML2View):
 class AssertionConsumer(SAML2View):
     def post(self):
         saml_request = request.form['SAMLResponse']
-        relay_state = request.form['RelayState']
+        if self.sp.get_acs_redirect_endpoint() == None:
+            relay_state = request.form['RelayState']
+        else:
+            relay_state = self.sp.make_absolute_url(self.sp.get_acs_redirect_endpoint())
 
         for handler in self.sp.get_idp_handlers():
             try:


### PR DESCRIPTION
Added class variables in ServiceProvider for logout_endpoint, login_return_endpoint, entity_id, and acs_redirect_endpoint, and added parameters in the create_blueprint method.
With acs_redirect_endpoint, you can explicitly set the relay_state in AssertionConsumer, for cases in which the SAML Request does not contain a relay_state parameter.
Now, if you don't want to use a url to the saml xml file as your entity_id (default behaviour), you can set the entity_id in ServiceProvider.

Fixed an issue with the Login class in views.py. It now supports setting the scheme to "https" (this happens in ServiceProvider's create_blueprint method).

Updated the example sp.py accordingly.

Linked Issues:
https://github.com/mx-moth/flask-saml2/issues/17
https://github.com/mx-moth/flask-saml2/issues/18
https://github.com/mx-moth/flask-saml2/issues/19